### PR TITLE
Add some actions permissions

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -135,10 +135,5 @@ ridedott/merge-me-action:
     contents: write
     pull-requests: read
 shogo82148/actions-check-permissions:
-# https://github.com/saucelabs/sauce-connect-action/issues/24
 saucelabs/sauce-connect-action:
-  permissions:
-    contents: write
 codecov/codecov-action:
-  permissions:
-    contents: write # not required for public repos

--- a/actions.yml
+++ b/actions.yml
@@ -133,3 +133,4 @@ github/codeql-action/analyze:
 ridedott/merge-me-action:
   permissions:
     contents: write
+shogo82148/actions-check-permissions:

--- a/actions.yml
+++ b/actions.yml
@@ -133,6 +133,7 @@ github/codeql-action/analyze:
 ridedott/merge-me-action:
   permissions:
     contents: write
+    pull-requests: read
 shogo82148/actions-check-permissions:
 # https://github.com/saucelabs/sauce-connect-action/issues/24
 saucelabs/sauce-connect-action:

--- a/actions.yml
+++ b/actions.yml
@@ -134,3 +134,7 @@ ridedott/merge-me-action:
   permissions:
     contents: write
 shogo82148/actions-check-permissions:
+# https://github.com/saucelabs/sauce-connect-action/issues/24
+saucelabs/sauce-connect-action:
+  permissions:
+    contents: write

--- a/actions.yml
+++ b/actions.yml
@@ -130,3 +130,6 @@ github/codeql-action/analyze:
     contents: read
     pull-requests: read
     security-events: write
+ridedott/merge-me-action:
+  permissions:
+    contents: write

--- a/actions.yml
+++ b/actions.yml
@@ -138,3 +138,6 @@ shogo82148/actions-check-permissions:
 saucelabs/sauce-connect-action:
   permissions:
     contents: write
+codecov/codecov-action:
+  permissions:
+    contents: write # not required for public repos


### PR DESCRIPTION
## [ridedott/merge-me-action](https://github.com/ridedott/merge-me-action)

This Action approves and attempts to merge Pull Requests when triggered.

## [shogo82148/actions-check-permissions](https://github.com/shogo82148/actions-check-permissions)

A GitHub Action for checking the `contents` permissions of GITHUB_TOKEN.

FYI: https://shogo82148.github.io/blog/2021/03/17/actions-check-permissions/

## [saucelabs/sauce-connect-action](https://github.com/saucelabs/sauce-connect-action)

A GitHub action to launch Sauce Connect Proxy. ~~This action requires an access token, so it requires `contents: write` permissions.~~

FYI: https://github.com/saucelabs/sauce-connect-action/issues/24

## [codecov/codecov-action](https://github.com/codecov/codecov-action)

Easily upload coverage reports to Codecov from GitHub Actions. This action requires an access token for **private repositories**. ~~If you add to the logic whether or not an access token is passed to this action, it can detect permissions more flexibly.~~



