### PR TITLE
fix: logging unknown actions names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -232,7 +232,7 @@ export const updateGitHubActions = async (
         );
     }
     if (options.verbose) {
-        console.info("process: " + options.filePath);
+        console.info("\nprocess: " + options.filePath);
     }
     const content = yaml.parse(yamlContent) satisfies GitHubActionSchema;
     if (hasPermissions(content)) {
@@ -245,9 +245,11 @@ export const updateGitHubActions = async (
     if (options.verbose) {
         console.info("requires permissions: ");
         console.info(
-            yaml.stringify({
-                permissions: requiresPermissions
-            })
+            yaml
+                .stringify({
+                    permissions: requiresPermissions
+                })
+                .trimEnd()
         );
     }
     return insertPermissions(yamlContent, requiresPermissions);

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ export const computePermissions = async (
     // if found unknown actions, return default permissions
     if (knownPermissions.length !== usesActions.length) {
         if (options.verbose) {
-            const unknownActionNames = knownPermissions
+            const unknownActionNames = usesActions
                 .filter(([name]) => {
                     return !Object.prototype.hasOwnProperty.call(definitions, name);
                 })


### PR DESCRIPTION
## Description of change
・Fixed a issue in which undefined action names were not logged correctly when the `--verbose` option was used.

_before_
```
$ npx @pkgdeps/update-github-actions-permissions ".github/workflows/*.{yaml,yml}" --verbose
...
found unknown actions(), use write-all
...
```

_after_
```
$ npx @pkgdeps/update-github-actions-permissions ".github/workflows/*.{yaml,yml}" --verbose
...
found unknown actions(minorActions, privateActions), use write-all
...
```

・I also tried to make the log output with a new line for each process.
_before_
```
$ npx @pkgdeps/update-github-actions-permissions ".github/workflows/*.{yaml,yml}" --verbose
useRuleDefinitions: default, secure-workflows
process: .github/workflows/create-release-pr.yml
already have permissions
process: .github/workflows/test.yml
found unknown actions(minorActions), use write-all
requires permissions:
permissions: write-all
process: .github/workflows/cron-update-third-party.yml
already have permissions
```

_after_
```
$ npx @pkgdeps/update-github-actions-permissions ".github/workflows/*.{yaml,yml}" --verbose
useRuleDefinitions: default, secure-workflows

process: .github/workflows/create-release-pr.yml
already have permissions

process: .github/workflows/test.yml
found unknown actions(minorActions), use write-all
requires permissions:
permissions: write-all

process: .github/workflows/cron-update-third-party.yml
already have permissions
```