### PR TITLE
Add k1LoW/octocov-action

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -62,6 +62,11 @@ JS-DevTools/npm-publish:
   permissions:
     contents: read
     packages: write
+k1LoW/octocov-action:
+  permissions:
+    pull-requests: write
+    contents: read
+    actions: read
 necojackarc/auto-request-review:
   permissions:
     contents: read


### PR DESCRIPTION
This PR adds action security for https://github.com/k1LoW/octocov-action

I am not an author of the action, but just an user.

I've observed those permissions on actual GitHub Action runs, since it is not obvious to understand how GH API is used in the action.

